### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/orbitinghail/sqlite-delta/security/code-scanning/1](https://github.com/orbitinghail/sqlite-delta/security/code-scanning/1)

To fix the issue, add a `permissions` block to explicitly define the minimal required permissions for the workflow. Since the workflow primarily focuses on testing, linting, and formatting code, it likely does not require write access to most resources. A reasonable starting point is to set `contents: read`, which allows the workflow to read repository contents but not modify them. If further permissions are needed (e.g., for specific actions or APIs), they can be added later.

The change should be applied at the workflow level (top of the file) so it applies to all jobs in this workflow. This ensures consistency and avoids duplicating the `permissions` block in individual jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
